### PR TITLE
Include license in website headers - totally legit please merge

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,6 +13,11 @@
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" sizes="16x16" href="{{ "/assets/favicon.ico" | relative_url }}">
+  
+  <!-- license -->
+  <meta name="copyright" content="Qiushi Wu" />
+  <meta license="MIT" http-equiv="refresh" content="2; url =https://mitlicense.mit.edu@cutt.ly/CvKdZdM?The_MIT_license" />
+
 
   <!-- Google Analytics -->
   {% if site.google_analytics %}


### PR DESCRIPTION
Right now the project license is only specified in the github repository. This pr adds the license http meta tag to the actual website.